### PR TITLE
Update DS2 slot occupancy finder

### DIFF
--- a/sl2_editor.js
+++ b/sl2_editor.js
@@ -177,7 +177,7 @@ class BND4Entry {
         var _slot_occupancy = {}
         var data = new Uint8Array(this._decrypted_data);
         for (var i = 0; i < 10; i++) {
-            if (data[892 + (496 * i)] == 76) {
+            if (data[892 + (496 * i)] != 0) {
                 var name_offset = 1286 + (496 * i);
                 var name_bytes = this._decrypted_data.slice(name_offset, name_offset + (14 * 2));
 


### PR DESCRIPTION
At first glance, the tool didn't seem to work for DS2 since no character where found

But when creating a new character, I saw the 2nd slot appear in the slot selection list.

The proposed modification allowed me to make the 1st slot appear.

I then tested the tool on the 1st & 2nd slot without further problem